### PR TITLE
feat(ci): add GitHub Actions CI for Python lint, syntax, and JS smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python-lint:
+    name: Python lint (ruff)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dev tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: ruff check
+        run: ruff check .
+
+      - name: ruff format --check (advisory)
+        # Advisory only for now — gradual rollout. Flip to blocking after a
+        # one-shot 'ruff format .' commit lands in main.
+        run: ruff format --check . || echo "::warning::Some files would be reformatted by ruff format"
+
+  python-syntax:
+    name: Python syntax check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Compile all Python files
+        run: |
+          python -m compileall -q midi_server.py telegram_bot.py
+
+  js-lint:
+    name: JS / HTML smoke check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Validate JS syntax with node --check
+        run: |
+          node --check form-handler.js
+          node --check script.js
+          node --check server.js
+
+      - name: HTML smoke check
+        run: |
+          # Minimal sanity: index.html must contain <!doctype html> and <body>
+          grep -i '<!doctype html' index.html >/dev/null || { echo '::error::index.html missing doctype'; exit 1; }
+          grep -i '<body'           index.html >/dev/null || { echo '::error::index.html missing <body>'; exit 1; }
+          echo "HTML OK"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[tool.ruff]
+target-version = "py311"
+line-length = 110
+extend-exclude = [".venv", "build", "dist"]
+
+[tool.ruff.lint]
+# A pragmatic baseline: pyflakes + pycodestyle errors + import sort + bugbear,
+# but ignore noisy rules so CI passes on the existing codebase without rewrites.
+select = ["E", "F", "I", "B", "UP"]
+ignore = [
+  "E501",  # line too long — handled by formatter, not blocking
+  "E741",  # ambiguous variable name (we use `l` etc. in MIDI math)
+  "B008",  # do not perform function calls in argument defaults (FastAPI Depends pattern)
+  "UP015", # `open(...)` mode redundancy — cosmetic
+  "E402",  # module-level imports not at top: telegram_bot.py loads .env first by design
+  "I001",  # import block ordering: keep current grouping with section comments
+  "UP017", # `datetime.timezone.utc` is fine; UTC alias is 3.11+ only and adds churn
+  "UP007", # `Optional[X]` over `X | None` is fine for stable libraries
+  "UP035", # `typing.X` over modernized imports — cosmetic
+  "B904",  # raise-from chains: not worth churning telegram error handling
+]
+
+[tool.ruff.format]
+quote-style = "double"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+# Linting + formatting + type checking for CI
+ruff==0.6.9
+mypy==1.11.2


### PR DESCRIPTION
## Summary

Resolves #4 — adds a working CI pipeline.

## Jobs

1. **python-lint** — `ruff check` + `ruff format --check` (advisory for now)
2. **python-syntax** — `python -m compileall` on `midi_server.py` and `telegram_bot.py`
3. **js-lint** — `node --check` on all .js files, plus HTML smoke check on `index.html`

## Configuration

`pyproject.toml` is added with a **pragmatic** ruff config: it ignores cosmetic rules (`E501`, `E402`, `I001`, `UP017`, `UP007`, `UP035`, `B904`, `B008`, `UP015`, `E741`) so CI passes on the existing codebase without forced rewrites of working code. The format check is **advisory** — it warns but doesn't block. Once a one-shot `ruff format .` commit lands, we can flip it to blocking.

## Local verification

- `ruff check .` → All checks passed
- `python -m compileall midi_server.py telegram_bot.py` → success
- `node --check form-handler.js script.js server.js` → all OK
- HTML smoke check passes

🤖 Generated with [Perplexity Computer](https://perplexity.ai)